### PR TITLE
Exercise 1 for exam

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.gson)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+    <uses-permission android:name="android.permission.WRITE_CACHE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/MainActivity.kt
@@ -1,7 +1,11 @@
 package edu.iesam.examaad1eval
 
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import edu.iesam.examaad1eval.features.ex1.data.Ex1DataRepository
+import edu.iesam.examaad1eval.features.ex1.data.local.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex1.data.remote.MockEx1RemoteDataSource
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -11,11 +15,27 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         executeExercise1()
-        executeExercise2()
+        //executeExercise2()
     }
 
     private fun executeExercise1(){
         //Ejecutar el ejercicio 1 desde aquí llamando al Ex1DataRepository directamente
+        val localDataSource = Ex1XmlLocalDataSource(this)
+        val remoteDataSource = MockEx1RemoteDataSource()
+        val repository = Ex1DataRepository(localDataSource, remoteDataSource)
+        val users = repository.getUsers()
+        for (user in users) {
+            Log.d("@dev", "user: $user")
+        }
+        val items = repository.getItems()
+        for (item in items) {
+            Log.d("@dev", "item: $item")
+        }
+        val services = repository.getServices()
+        for (service in services) {
+            Log.d("@dev", "service: $service")
+        }
+
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/Ex1DataRepository.kt
@@ -1,0 +1,43 @@
+package edu.iesam.examaad1eval.features.ex1.data
+
+import edu.iesam.examaad1eval.features.ex1.data.local.Ex1XmlLocalDataSource
+import edu.iesam.examaad1eval.features.ex1.data.remote.MockEx1RemoteDataSource
+import edu.iesam.examaad1eval.features.ex1.domain.Ex1Repository
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1DataRepository(
+    private val localDataSource: Ex1XmlLocalDataSource,
+    private val remoteDataSource: MockEx1RemoteDataSource
+): Ex1Repository {
+    override fun getUsers(): List<User> {
+        val users = localDataSource.getUsers()
+        if (users.isEmpty()) {
+            val remoteUsers = remoteDataSource.getUsers()
+            localDataSource.saveUsers(remoteUsers)
+            return remoteUsers
+        }
+        return users
+    }
+
+    override fun getItems(): List<Item> {
+        val items = localDataSource.getItems()
+        if (items.isEmpty()) {
+            val remoteItems = remoteDataSource.getItems()
+            localDataSource.saveItems(remoteItems)
+            return remoteItems
+        }
+        return items
+    }
+
+    override fun getServices(): List<Services> {
+        val services = localDataSource.getServices()
+        if (services.isEmpty()) {
+            val remoteServices = remoteDataSource.getServices()
+            localDataSource.saveServices(remoteServices)
+            return remoteServices
+        }
+        return services
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/local/Ex1XmlLocalDataSource.kt
@@ -1,0 +1,56 @@
+package edu.iesam.examaad1eval.features.ex1.data.local
+
+import android.app.Service
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
+
+class Ex1XmlLocalDataSource(context: Context) {
+    val sharedPreferences = context.getSharedPreferences("db-exam", Context.MODE_PRIVATE)
+    val editor = sharedPreferences.edit()
+    val gson = Gson()
+
+    fun saveItems(items: List<Item>) {
+        val itemsJson = gson.toJson(items)
+        editor.putString("items", itemsJson).apply()
+    }
+
+    fun saveServices(services: List<Services>) {
+        val servicesJson = gson.toJson(services)
+        editor.putString("services", servicesJson).apply()
+    }
+
+    fun saveUsers(users: List<User>) {
+        val usersJson = gson.toJson(users)
+        editor.putString("users", usersJson).apply()
+    }
+    fun getItems(): List<Item> {
+        val itemsJson = sharedPreferences.getString("items", null)
+        return if (itemsJson != null) {
+            gson.fromJson(itemsJson, object : TypeToken<List<Item>>() {}.type)
+        } else {
+            emptyList()
+        }
+    }
+
+    fun getServices(): List<Services> {
+        val servicesJson = sharedPreferences.getString("services", null)
+        return if (servicesJson != null) {
+            gson.fromJson(servicesJson, object : TypeToken<List<Service>>() {}.type)
+        } else {
+            emptyList()
+        }
+    }
+
+    fun getUsers(): List<User> {
+        val usersJson = sharedPreferences.getString("users", null)
+        return if (usersJson != null) {
+            gson.fromJson(usersJson, object : TypeToken<List<User>>() {}.type)
+        } else {
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/remote/MockEx1RemoteDataSource.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/data/remote/MockEx1RemoteDataSource.kt
@@ -1,4 +1,8 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.data.remote
+
+import edu.iesam.examaad1eval.features.ex1.domain.Item
+import edu.iesam.examaad1eval.features.ex1.domain.Services
+import edu.iesam.examaad1eval.features.ex1.domain.User
 
 class MockEx1RemoteDataSource {
 

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Models.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.domain
 
 data class User(val id: String, val name: String, val surname: String)
 data class Item(val id: String, val name: String, val price: Double)

--- a/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Repository.kt
+++ b/app/src/main/java/edu/iesam/examaad1eval/features/ex1/domain/Ex1Repository.kt
@@ -1,4 +1,4 @@
-package edu.iesam.examaad1eval.features.ex1
+package edu.iesam.examaad1eval.features.ex1.domain
 
 interface Ex1Repository {
     fun getUsers(): List<User>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.6.0"
+gson = "2.10"
 kotlin = "1.9.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -12,6 +13,7 @@ constraintlayout = "2.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
---
name: ExamAAD1Eval
about: Cache SharedPreferences
title: "[Feature]: Excersice 1 "
labels: ["excersices"]
projects: ["ExamAAD1Eval"]
assignees: ''
---
## 🤔 Descripción del problema a resolver

The plan is to use shared preferences to store the provided data at the cache level and then retrieve it from there.

## 💡 Proceso seguido para resolver el problema.

A class was created to manage an XML file as a local database, allowing data to be entered remotely and retrieved when requested.

## 👩‍💻 Resumen de los cambios introducidos

The Gson library has been added to serialize lists, allowing them to be stored in the XML file using SharedPreferences.>

## 📸 Screenshot o Video


![listShared](https://github.com/user-attachments/assets/23eeb9a6-b77e-4e98-b77d-821ed251d9c3)
![logShared](https://github.com/user-attachments/assets/dce5aedf-eb99-4ce2-8169-64ed7a768207)

## ✋ Notas adicionales (Disclaimer)
<!-- ¿Deberíamos saber algo sobre algo que no esperábamos? -->

## 🌈 Añade un Gif que represente a esta PR
<!-- ¿Cómo te has sentido desarrollando esta PR -->

## ✅ Checklist
- [ ] La rama tiene el formato correcto: tipo_de_issue/numero_issue/descripcion.
- [ ] He añadido un título a la PR descriptivo.
- [ ] Me he asignado como autor.
- [ ] He asignado a dos revisores.
- [ ] He relacionado la PR con la Issue.